### PR TITLE
fix usebruno/burno#1357: access home filesystem

### DIFF
--- a/com.usebruno.Bruno.yml
+++ b/com.usebruno.Bruno.yml
@@ -11,6 +11,7 @@ finish-args:
   - --socket=fallback-x11
   - --share=ipc
   - --device=dri
+  - --filesystem=home
 modules:
   - name: unappimage
     buildsystem: simple


### PR DESCRIPTION
On a new flathub-based installation, the user cannot create new collections in their home directory.
Therefore, adding the permission here.

Compare
* https://github.com/usebruno/bruno/issues/1357
* https://docs.flatpak.org/en/latest/sandbox-permissions.html