### PR TITLE
Update license to valid SPDX license identifier for MIT

### DIFF
--- a/com.usebruno.Bruno.metainfo.xml
+++ b/com.usebruno.Bruno.metainfo.xml
@@ -9,7 +9,7 @@
   <url type="bugtracker">https://github.com/usebruno/bruno/issues</url>
 
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>LicenseRef-MIT-</project_license>
+  <project_license>MIT</project_license>
   <content_rating type="oars-1.1" />
 
   <description>


### PR DESCRIPTION
Flathub entry for bruno has invalid license id. 
![Screenshot from 2024-05-07 23-03-25](https://github.com/flathub/com.usebruno.Bruno/assets/2108093/9845e646-3da9-425c-8cc6-282b00a385c4)

The open source bruno is released under `MIT`, and not `LicenseRef-MIT-`, the entry may be ehnanced with very much inviting
![Screenshot from 2024-05-07 23-05-16](https://github.com/flathub/com.usebruno.Bruno/assets/2108093/9b84dbcc-28fb-4f7a-a3ed-75198d2c1218)
with a link to the project website and everything.

If I am wrong, however, and the project does not pass the criteria for relase under MIT, reject this PR, but please update the license to valid proprietary license id *with url provided:*.
E.g. 
```
<project_license>LicenseRef-proprietary=https://usebruno.com/license</project_license>
```
Resulting displaying correct value without halftruth about non-existend license:
![Screenshot from 2024-05-07 23-08-08](https://github.com/flathub/com.usebruno.Bruno/assets/2108093/912a59c4-761b-4eee-a5ab-0894eb457040)


resolves #1 