### PR TITLE
Add missing released versions to metainfo.xml

### DIFF
--- a/com.usebruno.Bruno.metainfo.xml
+++ b/com.usebruno.Bruno.metainfo.xml
@@ -32,6 +32,9 @@
   </screenshots>
 
   <releases>
+    <release version="v1.14.0" date="2024-04-22"></release>
+    <release version="v1.13.1" date="2024-04-15"></release>
+    <release version="v1.13.0" date="2024-04-13"></release>
     <release version="v1.12.3" date="2024-03-26"></release>
     <release version="v1.12.2" date="2024-03-21"></release>
     <release version="v1.11.0" date="2024-03-13"></release>


### PR DESCRIPTION
Flathub / Gnome Store advertises old version of the app (even though the latest one is downloaded).