### PR TITLE
Make license dual license

### DIFF
--- a/com.usebruno.Bruno.metainfo.xml
+++ b/com.usebruno.Bruno.metainfo.xml
@@ -9,7 +9,7 @@
   <url type="bugtracker">https://github.com/usebruno/bruno/issues</url>
 
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>LicenseRef-proprietary</project_license>
+  <project_license>MIT AND LicenseRef-proprietary</project_license>
   <content_rating type="oars-1.1" />
 
   <description>


### PR DESCRIPTION
Enables Bruno to support dual MIT and proprietary licensed.