### PR TITLE
Use official AppImage extraction instead of unappimage

### DIFF
--- a/apply_extra.sh
+++ b/apply_extra.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
-# Extract the appimage
+# Make the AppImage executable
 chmod +x bruno.appimage
-unappimage bruno.appimage >/dev/null
 
-# Move all the data to /app/extra/bruno
+# Use the AppImage's own extractor
+./bruno.appimage --appimage-extract >/dev/null
+
+# Move extracted contents
 mv squashfs-root bruno
 
 # Clean up


### PR DESCRIPTION
This PR replaces the use of `unappimage` with the AppImage’s built-in extraction mechanism:

```
- unappimage bruno.appimage
+ ./bruno.appimage --appimage-extract
```

The AppImage runtime provides its own extraction method (`--appimage-extract`) which more accurately reproduces the original filesystem layout compared to third-party tools like `unappimage`.

While `unappimage` works in most cases, it can introduce subtle differences during SquashFS extraction (e.g. padding or alignment changes). These differences don’t affect normal execution of Bruno, but they can cause inconsistencies when inspecting files at the byte level (for example, when validating `.asar` integrity or offsets).